### PR TITLE
Update vswhere version to 3.1.7

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,11 +22,14 @@ about:
   home: https://github.com/microsoft/vswhere
   license: MIT
   license_file: LICENSE.txt
+  license_family: MIT
   summary: CLI tool to locate Visual Studio 2017 and newer installations
   description: |
     vswhere is designed to be a redistributable, single-file executable that
     can be used in build or deployment scripts to find where Visual Studio
     - or other products in the Visual Studio family - is located.
+  dev_url: https://github.com/microsoft/vswhere
+  doc_url: https://github.com/Microsoft/vswhere/wiki
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,5 @@ about:
 extra:
   recipe-maintainers:
     - wolfv
-
-skip-lints:
-  # binary repack
-  - missing_section
+  skip-lints:
+    - missing_section

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,12 +1,13 @@
-{% set version = "2.8.4" %}
+{% set version = "3.1.7" %}
+{% set name = "vswhere" %}
 
 package:
-  name: vswhere
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://github.com/microsoft/vswhere/releases/download/{{ version }}/vswhere.exe
-  sha256: e50a14767c27477f634a4c19709d35c27a72f541fb2ba5c3a446c80998a86419
+  url: https://github.com/microsoft/{{ name }}/releases/download/{{ version }}/{{ name }}.exe
+  sha256: c54f3b7c9164ea9a0db8641e81ecdda80c2664ef5a47c4191406f848cc07c662
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,6 +16,7 @@ build:
 
 test:
   commands:
+    - if not exist %LIBRARY_BIN%\\vswhere.exe  exit 1
     - vswhere
 
 about:
@@ -34,3 +35,7 @@ about:
 extra:
   recipe-maintainers:
     - wolfv
+
+skip-lints:
+  # binary repack
+  - missing_section


### PR DESCRIPTION
vswhere 3.1.7

**Destination channel:** defaults

### Links

- [PKG-8969](https://anaconda.atlassian.net/browse/PKG-8969) 
- dev_url: https://github.com/microsoft/vswhere/tree/3.1.7
- conda_forge: https://github.com/conda-forge/vswhere-feedstock
- pypi: --
- pypi inspector: --

Explanation of changes:
- new version number


[PKG-8969]: https://anaconda.atlassian.net/browse/PKG-8969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ